### PR TITLE
Fixed 'can't update with same old task' issue

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,7 @@ const App = () => {
     if (!inputValue) return;
   
     // Check for duplicates
-    if (todos.includes(inputValue.trim())) {
+    if (editIndex === null && todos.includes(inputValue.trim())) {
       alert("This todo item already exists!"); 
       return;
     }


### PR DESCRIPTION
A user should be able to save a task even if the user pressed edit and didn't change anything in it. Before user couldn't do it.